### PR TITLE
Replace text Teacher Dashboard with Grove Configuration

### DIFF
--- a/app/views/shared/_navbar.html.erb
+++ b/app/views/shared/_navbar.html.erb
@@ -10,7 +10,7 @@
 
     <div class="collapse navbar-collapse" id="navbar-collapse-1">
       <ul class="nav navbar-nav navbar-right" style="margin-top:9px">
-        <li><%= link_to "Teacher Dashboard", admin_dashboard_path %></li>
+        <li><%= link_to "Grove Configuration", admin_dashboard_path %></li>
         <li><%= link_to "Log out", destroy_user_session_path, method: 'delete' %></li>
       </ul>
     </div>

--- a/spec/integration/admin/groves_spec.rb
+++ b/spec/integration/admin/groves_spec.rb
@@ -84,7 +84,7 @@ RSpec.feature 'Managing Groves' do
     end
 
     it 'shows navigation links' do
-      expect(dashboard_page).to have_content("Teacher Dashboard")
+      expect(dashboard_page).to have_content("Grove Configuration")
       expect(dashboard_page).to have_content("Grove Monitor")
       expect(dashboard_page).to have_content("Grove Playlist Manager")
     end

--- a/spec/integration/authentication/sign_in_spec.rb
+++ b/spec/integration/authentication/sign_in_spec.rb
@@ -10,7 +10,7 @@ RSpec.feature 'User can login' do
       login(teacher)
       expect(current_path).to eq(admin_dashboard_path)
       expect(page).to have_content("Hello, #{teacher.first_name}")
-      expect(page).to have_content("Teacher Dashboard")
+      expect(page).to have_content("Grove Configuration")
       expect(page).to have_content("Signed in successfully.")
     end
   end

--- a/spec/integration/navigation_spec.rb
+++ b/spec/integration/navigation_spec.rb
@@ -11,7 +11,7 @@ RSpec.feature 'Navigation options' do
 
       expect(page).to have_content("Hello, #{teacher.first_name}")
       expect(page).to have_content("Signed in successfully.")
-      expect(page).to have_content("Teacher Dashboard")
+      expect(page).to have_content("Grove Configuration")
       expect(page).to have_content("Grove Monitor")
       expect(page).to have_content("Grove Playlist Manager")
     end
@@ -22,7 +22,7 @@ RSpec.feature 'Navigation options' do
       login(student)
       visit '/'
 
-      expect(page).not_to have_content("Teacher Dashboard")
+      expect(page).not_to have_content("Grove Configuration")
       expect(page).not_to have_content("Grove Monitor")
       expect(page).not_to have_content("Grove Playlist Manager")
     end
@@ -32,7 +32,7 @@ RSpec.feature 'Navigation options' do
     it "does not a display a nav bar" do
       visit '/'
 
-      expect(page).not_to have_content("Teacher Dashboard")
+      expect(page).not_to have_content("Grove Configuration")
       expect(page).not_to have_content("Grove Monitor")
       expect(page).not_to have_content("Grove Playlist Manager")
     end


### PR DESCRIPTION
Simple change to clear a card: 
- "Teacher Dashboard" phrase changed to "Grove Configuration"

The card also mentioned these changes which appear to be complete: 
- When assigning a Teacher to a Grove, the word "Grove" should be visible
- In the dropdown to assign a Teacher to a Grove, remove the word "collections"
