### PR TITLE
Fix grove name

### DIFF
--- a/app/controllers/admin/students_controller.rb
+++ b/app/controllers/admin/students_controller.rb
@@ -18,7 +18,7 @@ module Admin
     end
 
     def form_attributes
-      whitelist
+      collection_attributes
     end
 
     def collection_attributes

--- a/app/controllers/admin/teachers_controller.rb
+++ b/app/controllers/admin/teachers_controller.rb
@@ -10,7 +10,7 @@ module Admin
     protected
 
     def form_attributes
-      [:name, :email, :grove]
+      [:name, :email, :grove_name]
     end
 
     def collection_attributes


### PR DESCRIPTION
changes grove object id on admin/teachers/:id to show grove name instead 

changes grove id on admin/students/:id to show grove name instead 
