### PR TITLE
Decouple the association between events and scans

### DIFF
--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -3,9 +3,12 @@ class Event < ActiveRecord::Base
   belongs_to :student, foreign_key: :user_id
   belongs_to :activity
   belongs_to :creator, class_name: "Teacher"
-  has_many :scans, dependent: :destroy
 
   def scanned_in?
-    !scans.where(correct: true).empty?
+    scans.where('timestamp > ? AND timestamp < ?', start_time, end_time).present?
+  end
+
+  def scans
+    Scan.where(correct: true, student:student, location: location)
   end
 end

--- a/app/models/scan.rb
+++ b/app/models/scan.rb
@@ -1,5 +1,5 @@
 class Scan < ActiveRecord::Base
-  belongs_to :event
+  # belongs_to :event
   belongs_to :location
   belongs_to :student, foreign_key: :user_id
 end

--- a/app/models/scan.rb
+++ b/app/models/scan.rb
@@ -1,5 +1,4 @@
 class Scan < ActiveRecord::Base
-  # belongs_to :event
   belongs_to :location
   belongs_to :student, foreign_key: :user_id
 end

--- a/app/models/scan_creator.rb
+++ b/app/models/scan_creator.rb
@@ -1,7 +1,6 @@
 class ScanCreator
   def self.create(student, scan_params)
     Scan.create!(student: student,
-                 event_id: student.current_event.id,
                  location_id: scan_params[:scanned_data],
                  timestamp: Time.now,
                  correct: scan_params[:location_id] == scan_params[:scanned_data])

--- a/db/migrate/20160810212356_add_duration_to_event.rb
+++ b/db/migrate/20160810212356_add_duration_to_event.rb
@@ -1,0 +1,5 @@
+class AddDurationToEvent < ActiveRecord::Migration
+  def change
+    add_column :events, :duration, :integer, default: 0
+  end
+end

--- a/db/migrate/20160811141420_remove_event_assoications.rb
+++ b/db/migrate/20160811141420_remove_event_assoications.rb
@@ -1,0 +1,5 @@
+class RemoveEventAssoications < ActiveRecord::Migration
+  def change
+    remove_column :scans, :event_id
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160804173540) do
+ActiveRecord::Schema.define(version: 20160810212356) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -33,10 +33,11 @@ ActiveRecord::Schema.define(version: 20160804173540) do
     t.integer  "user_id"
     t.datetime "start_time"
     t.datetime "end_time"
-    t.datetime "created_at",  null: false
-    t.datetime "updated_at",  null: false
+    t.datetime "created_at",              null: false
+    t.datetime "updated_at",              null: false
     t.integer  "activity_id"
     t.integer  "creator_id"
+    t.integer  "duration",    default: 0
   end
 
   add_index "events", ["activity_id"], name: "index_events_on_activity_id", using: :btree

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160810212356) do
+ActiveRecord::Schema.define(version: 20160811141420) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -93,7 +93,6 @@ ActiveRecord::Schema.define(version: 20160810212356) do
   end
 
   create_table "scans", force: :cascade do |t|
-    t.integer  "event_id"
     t.integer  "location_id"
     t.boolean  "correct"
     t.datetime "timestamp"
@@ -102,7 +101,6 @@ ActiveRecord::Schema.define(version: 20160810212356) do
     t.integer  "user_id"
   end
 
-  add_index "scans", ["event_id"], name: "index_scans_on_event_id", using: :btree
   add_index "scans", ["location_id"], name: "index_scans_on_location_id", using: :btree
   add_index "scans", ["user_id"], name: "index_scans_on_user_id", using: :btree
 
@@ -162,7 +160,6 @@ ActiveRecord::Schema.define(version: 20160810212356) do
   add_foreign_key "playlist_activities", "activities"
   add_foreign_key "playlist_activities", "focus_areas"
   add_foreign_key "playlist_activities", "users"
-  add_foreign_key "scans", "events"
   add_foreign_key "scans", "locations"
   add_foreign_key "scans", "users"
   add_foreign_key "user_roles", "roles"

--- a/spec/integration/admin/grove_monitor_spec.rb
+++ b/spec/integration/admin/grove_monitor_spec.rb
@@ -74,7 +74,7 @@ RSpec.feature 'Grove Monitor' do
 
     it 'shows students that are scanned in' do
       student1.events.create(location: location, start_time: Time.now-100, end_time: Time.now+3600)
-      Event.last.scans.create(location: location, timestamp: Time.now, correct:true, user_id: student1.id)
+      Scan.create(location: location, timestamp: Time.now, correct:true, user_id: student1.id)
       grove_monitor_page.visit_page.click_on(location.name)
 
       expect(grove_monitor_page).to have_css('.scanned-in')

--- a/spec/integration/compass_spec.rb
+++ b/spec/integration/compass_spec.rb
@@ -51,8 +51,7 @@ RSpec.feature 'Student Compass' do
 
     context "student is checked in" do
       it "does not show the scan button" do
-        create(:scan, event: event,
-                      location: location,
+        create(:scan, location: location,
                       correct: true,
                       timestamp: Time.now,
                       student: student)

--- a/spec/models/event_spec.rb
+++ b/spec/models/event_spec.rb
@@ -3,5 +3,27 @@ require 'rails_helper'
 RSpec.describe Event, type: :model do
   it { should belong_to :student }
   it { should belong_to :location }
-  it { should have_many :scans }
+
+  describe 'scanned_in?' do
+    before { Timecop.freeze }
+    after { Timecop.return }
+
+    let(:student) { create(:student) }
+    let(:location) { create(:location) }
+
+    it 'finds a scan for a specific event' do
+      scan = create(:scan, location: location, student: student, timestamp: 3.minutes.ago, correct: true)
+      event = create(:event, student: student, location: location, start_time: 15.minutes.ago, end_time: 30.minutes.from_now)
+      expect(event.scans).to include(scan)
+      expect(event.scanned_in?).to eq(true)
+    end
+
+    it 'does not find scans before the current timeframe' do
+      event = create(:event, student: student, location: location, start_time: 15.minutes.ago, end_time: 30.minutes.from_now)
+      scan = create(:scan, location: location, student: student, timestamp: 20.minutes.ago, correct: true)
+      expect(event.scans).to include(scan)
+      expect(event.scanned_in?).to eq(false)
+    end
+
+  end
 end

--- a/spec/models/scan_spec.rb
+++ b/spec/models/scan_spec.rb
@@ -2,5 +2,4 @@ require 'rails_helper'
 
 RSpec.describe Scan, type: :model do
   it { should belong_to :location }
-  it { should belong_to :event }
 end

--- a/spec/support/factories.rb
+++ b/spec/support/factories.rb
@@ -56,8 +56,8 @@ FactoryGirl.define do
         create(:playlist_activity, activity: activity, student: student1, focus_area: focus_area)
         event = create(:event, student: student1, location: location1)
         event2 = create(:event, student: student2, location: location1)
-        scan = create(:scan, event: event, location: location2)
-        scan2 = create(:scan, event: event2, location: location1)
+        scan = create(:scan, location: location2)
+        scan2 = create(:scan, location: location1)
       end
     end
 
@@ -71,8 +71,8 @@ FactoryGirl.define do
         create(:playlist_activity, activity: activity, student: student1, focus_area: focus_area)
         event = create(:event, student: student1, location: location1)
         event2 = create(:event, student: student2, location: location1)
-        scan = create(:scan, event: event, location: location2)
-        scan2 = create(:scan, event: event2, location: location1)
+        scan = create(:scan, location: location2)
+        scan2 = create(:scan, location: location1)
       end
     end
 
@@ -86,8 +86,8 @@ FactoryGirl.define do
         create(:playlist_activity, activity: activity, student: student1, focus_area: focus_area)
         event = create(:event, student: student1, location: location)
         event2 = create(:event, student: student2, location: location)
-        scan = create(:scan, event: event, location: location, correct: true)
-        scan2 = create(:scan, event: event2, location: location, correct: true)
+        scan = create(:scan, location: location, correct: true)
+        scan2 = create(:scan, location: location, correct: true)
       end
     end
   end
@@ -127,7 +127,6 @@ FactoryGirl.define do
   end
 
   factory :scan do
-    event nil
     location nil
     timestamp Time.now + 10*60
     correct false


### PR DESCRIPTION
since events will be created and destroyed as the schedule changes, we need to _not_ have a relationship between the two, but still need to query in order to link the two. 
