### PR TITLE
Add Grove Picker to Admin Dashboard

### DIFF
--- a/app/controllers/admin/activities_controller.rb
+++ b/app/controllers/admin/activities_controller.rb
@@ -1,6 +1,6 @@
 class Admin::ActivitiesController < Admin::ResourceController
   def new
-    @locations = Location.where(grove_id: current_user.grove_id)
+    @locations = Location.where(grove_id: current_grove.id)
     super
   end
 
@@ -11,7 +11,7 @@ class Admin::ActivitiesController < Admin::ResourceController
   end
 
   def edit
-    @locations = Location.where(grove_id: current_user.grove_id)
+    @locations = Location.where(grove_id: current_grove.id)
     super
   end
 

--- a/app/controllers/admin/dashboard_controller.rb
+++ b/app/controllers/admin/dashboard_controller.rb
@@ -1,6 +1,6 @@
 class Admin::DashboardController < ApplicationController
   def show
     authorize(:admin_dashboard, :show?)
-    @groves = Grove.where.not(name: current_user.grove.name)
+    @groves = Grove.all
   end
 end

--- a/app/controllers/admin/dashboard_controller.rb
+++ b/app/controllers/admin/dashboard_controller.rb
@@ -1,5 +1,6 @@
 class Admin::DashboardController < ApplicationController
   def show
     authorize(:admin_dashboard, :show?)
+    @groves = Grove.where.not(name: current_user.grove.name)
   end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -5,4 +5,13 @@ class ApplicationController < ActionController::Base
   after_action :verify_authorized
 
   protect_from_forgery with: :exception
+
+  def current_grove
+    if current_user.admin?
+      Grove.find(session[:current_grove_id]) || current_user.grove
+    else
+      current_user.grove
+    end
+  end
+
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -3,12 +3,13 @@ class ApplicationController < ActionController::Base
   # For APIs, you may want to use :null_session instead.
   include Pundit
   after_action :verify_authorized
+  helper_method :current_grove
 
   protect_from_forgery with: :exception
 
   def current_grove
-    if current_user.admin?
-      Grove.find(session[:current_grove_id]) || current_user.grove
+    if current_user.admin? && !session[:current_grove_id].nil?
+      Grove.find(session[:current_grove_id])
     else
       current_user.grove
     end

--- a/app/views/admin/dashboard/show.html.erb
+++ b/app/views/admin/dashboard/show.html.erb
@@ -1,10 +1,11 @@
 <h2>Welcome</h2>
 
-
-<%= simple_form_for([:admin, current_user], html: { class: 'inline' }) do |form| %>
-  <%= form.input :grove_id,
-                 selected: [current_grove.id],
-                 include_blank: false,
-                 collection: @groves.map{|x| [x.name, x.id]} %>
-  <%= form.submit 'Change Grove', class: "btn btn-default" %>
+<% if current_user.admin? %>
+  <%= simple_form_for([:admin, current_user], html: { class: 'inline' }) do |form| %>
+    <%= form.input :grove_id,
+                   selected: [current_grove.id],
+                   include_blank: false,
+                   collection: @groves.map{|x| [x.name, x.id]} %>
+    <%= form.submit 'Change Grove', class: "btn btn-default" %>
+  <% end %>
 <% end %>

--- a/app/views/admin/dashboard/show.html.erb
+++ b/app/views/admin/dashboard/show.html.erb
@@ -1,15 +1,10 @@
 <h2>Welcome</h2>
 
-<div class="grove-picker">
-  <h3>Select Grove</h3>
-  <form class="form-inline">
-    <label for="groves">Grove</label>
-    <select class="form-control">
-      <option selected="selected"><%= current_user.grove.name %></option>
-      <% @groves.each do |grove| %>
-        <option><%= grove.name %></option>
-      <% end %>
-    </select>
-    <button type="submit" class="btn hollow-btn">Change Grove</button>
-  </form>
-</div>
+
+<%= simple_form_for([:admin, current_user], html: { class: 'inline' }) do |form| %>
+  <%= form.input :grove_id,
+                 selected: [current_grove.id],
+                 include_blank: false,
+                 collection: @groves.map{|x| [x.name, x.id]} %>
+  <%= form.submit 'Change Grove', class: "btn btn-default" %>
+<% end %>

--- a/app/views/admin/dashboard/show.html.erb
+++ b/app/views/admin/dashboard/show.html.erb
@@ -1,1 +1,15 @@
 <h2>Welcome</h2>
+
+<div class="grove-picker">
+  <h3>Select Grove</h3>
+  <form class="form-inline">
+    <label for="groves">Grove</label>
+    <select class="form-control">
+      <option selected="selected"><%= current_user.grove.name %></option>
+      <% @groves.each do |grove| %>
+        <option><%= grove.name %></option>
+      <% end %>
+    </select>
+    <button type="submit" class="btn hollow-btn">Change Grove</button>
+  </form>
+</div>


### PR DESCRIPTION
Adds grove picker to admin dashboard.

Unsure if this is the structure we want, as I'm not actually utilizing `session[:current_grove_id]` or the full functionality of the new `current_grove` method - absolutely open to feedback.

To Do:
1. Refactor dashboard view to place form in partial
2. Address re-routing on form submit (currently re-directs to teacher page)
3. Add Test coverage
